### PR TITLE
Handle invalid IFD

### DIFF
--- a/lib/exif/ExifImage.js
+++ b/lib/exif/ExifImage.js
@@ -187,6 +187,9 @@ ExifImage.prototype.extractExifData = function (data, start, length) {
 		// Each IFD entry consists of 12 bytes which we loop through and extract
 		// the data from
 		for (var i = 0; i < numberOfEntries; i++) {
+			if (numberOfEntries > 1000) {
+			  break;
+			}
 			var exifEntry = self.extractExifEntry(data, (ifdOffset + 2 + (i * 12)), tiffOffset, this.isBigEndian, ExifImage.TAGS.exif);
 			if (exifEntry && exifEntry.tagName !== null) this.exifData.exif[exifEntry.tagName] = exifEntry.value;
 		}


### PR DESCRIPTION
I ran `node-exif` over about 6000 photos, and it got hung up on just one. In this case, it looks like the IFD was invalid, so whereas there would normally be a few IFD entires to loop over, `node-exif` detected over 10000. Not exactly an infinite loop, but it effectively approximates one. This is definitely a problem with the image; `exiftool` fails gracefully and reports: "Bad ExifIFD directory" when reading the same file.

I was able to quickly fix this by adding a sanity check: if the number of entries exceeds 1000, something's got to be wrong so I had it bail out. There's probably a better way to solve this problem, but I figured submitting a pull request would at least be a good way to bring attention to this edge case.
