### PR TITLE
Fix for duplicate callback bug, issues #16 and #29

### DIFF
--- a/lib/exif/ExifImage.js
+++ b/lib/exif/ExifImage.js
@@ -110,7 +110,7 @@ ExifImage.prototype.processImage = function (data, callback) {
     }
 
   } catch (error) {
-    callback(error);
+    return callback(error);
   }
 
   callback(new Error('No Exif segment found in the given image.'));


### PR DESCRIPTION
As discussed in issue #16, this fixes an issue where the callback can be called twice upon error. There's an example image that causes this in issue #29. I have tested this and verified that it fixes the issue as I described it in #29.
