### PR TITLE
add simple wrapper/validator for ExifImage class 

### DIFF
--- a/lib/exif/PathExifMap.js
+++ b/lib/exif/PathExifMap.js
@@ -1,0 +1,37 @@
+var ExifImage = require('./ExifImage');
+
+String.prototype.endsWith = function (suffix) {
+    return this.indexOf(suffix, this.length - suffix.length) !== -1;
+};
+
+
+module.exports = function (path, callback) {
+
+    if (typeof path !== 'string') {
+        return new Error("Path must be a string.");
+    }
+    if (typeof callback !== 'function') {
+        return new Error("callback must be a function.");
+    }
+    if (!path.toLowerCase().endsWith('jpg')) {
+        return new Error("Path must be a jpg.");
+    }
+
+    try {
+        new ExifImage({
+            image: path
+        }, function (error, exifData) {
+
+            if (error) {
+                console.log(error)
+            } else {
+                callback(path, exifData);
+            }
+        });
+
+    } catch (error) {
+
+        console.log(error);
+    }
+
+};


### PR DESCRIPTION
This simple wrapper for the ExifImage class allows a user to pass a path to a '.jpg' file and a callback that receives both the image path and the extracted Exif Data.

Sample usage:

```javascript
var mapper = require('./lib/exif/PathExifMap.js');

mapper("/path/to/image.jpg", function (path, exifData) {

    console.log({
        path: path,
        exifData: exifData
    });
});
```
could return:

```javascript
{ path: '/path/to/image.jpg',
  exifData: 
   { image: 
      { ModifyDate: '2015:01:01 09:50:14',
        GPSInfo: 543,
        Model: 'Nexus 5',
        YCbCrPositioning: 1,
        ResolutionUnit: 2,
        YResolution: 72,
        ExifOffset: 166,
        XResolution: 72,
        Make: 'LGE' },
     thumbnail: 
      { YResolution: 72,
        ThumbnailLength: 39170,
        ThumbnailOffset: 888,
        Compression: 6,
        ResolutionUnit: 2,
        XResolution: 72 },
   //...
     interoperability: { InteropIndex: 'R98', InteropVersion: <Buffer 30 31 30 30> },
     makernote: {} 
  } 
}
```