### PR TITLE
Prevent memory problem in panasonic makernotes

### DIFF
--- a/lib/exif/makernotes/panasonic.js
+++ b/lib/exif/makernotes/panasonic.js
@@ -117,6 +117,7 @@ exports.extractMakernotes = function (data, makernoteOffset, tiffOffset) {
 
   for (var i = 0; i < numberOfEntries; i++) {
     var exifEntry = this.extractExifEntry(data, (ifdOffset + 2 + (i * 12)), makernoteOffset, false, tags);
+    if( ! exifEntry ) break; // stop if exifEntry starts to return false, prevents a process out of memory
     if (exifEntry && exifEntry.tagName !== null) makernoteData[exifEntry.tagName] = exifEntry.value;
   }
 


### PR DESCRIPTION
When trying some images a panasonic image had the problem that the tiffOffset seemed to be wrong resulting in a bunch of exifEntry variables that contain false.
This extra condition will detect these false exif entries and stop the loop.