### PR TITLE
#42 Fixed too much maker notes entries on panasonic

### DIFF
--- a/lib/exif/makernotes/panasonic.js
+++ b/lib/exif/makernotes/panasonic.js
@@ -113,8 +113,8 @@ exports.extractMakernotes = function (data, makernoteOffset, tiffOffset) {
   var ifdOffset = makernoteOffset + 12;
 
   // Get the number of entries and extract them
-  var numberOfEntries = data.getShort(ifdOffset, this.isBigEndian, tiffOffset);
-
+  var realNumberOfEntries = data.getShort(ifdOffset, this.isBigEndian, tiffOffset);
+  var numberOfEntries = realNumberOfEntries > 100 ? 0 : realNumberOfEntries;
   for (var i = 0; i < numberOfEntries; i++) {
     var exifEntry = this.extractExifEntry(data, (ifdOffset + 2 + (i * 12)), makernoteOffset, false, tags);
     if (exifEntry && exifEntry.tagName !== null) makernoteData[exifEntry.tagName] = exifEntry.value;


### PR DESCRIPTION
#42
The number of entries here was like 1644.
Problem is that it is not async, so it just cause memory leak :(.
So i fixed it simply like this, I am sure you'll find better way :)

Thank you for this exif reader, great thing, I would be screwed without. I owe you a beer:)