### PR TITLE
Add Buffer creation convenience 

### DIFF
--- a/lib/exif/ExifImage.js
+++ b/lib/exif/ExifImage.js
@@ -107,7 +107,21 @@ function ExifImage (options, callback) {
 //    callback(new Error('You have to provide an image, it is pretty hard to extract Exif data from nothing...'));
     return;
   }
-
+  
+  if (ops.hasOwnProperty('imageDataType')) {
+    switch (ops.imageDataType.toLowerCase()) {
+      case 'base64':
+        ops.image = ops.image.replace(/^data\:([^\;]+)\;base64,/gmi, '');
+        ops.image = Buffer.alloc(ops.image.length, ops.image, "base64");
+        break;
+      case 'arraybuffer':
+        ops.image = new Buffer(ops.image);
+        break;
+      default:
+        break;
+    }
+  } 
+  
   if (typeof callback !== 'function') {
     throw new Error('You have to provide a callback function.');
   }

--- a/lib/exif/ExifImage.js
+++ b/lib/exif/ExifImage.js
@@ -9,6 +9,17 @@ var debug = require('debug')('exif');
 
 var DEFAULT_MAX_ENTRIES=128;
 
+function base64ToArrayBuffer(base64) {
+  base64 = base64.replace(/^data\:([^\;]+)\;base64,/gmi, '');
+  var binary = atob(base64);
+  var len = binary.length;
+  var view = new Uint8Array(new ArrayBuffer(len));
+  for (var i = 0; i < len; i++) {
+      view[i] = binary.charCodeAt(i);
+  }
+  return view.buffer;
+}
+
 /**
  * Represents an image with Exif information. When instantiating it you have to
  * provide an image and a callback function which is called once all metadata
@@ -111,8 +122,7 @@ function ExifImage (options, callback) {
   if (ops.hasOwnProperty('imageDataType')) {
     switch (ops.imageDataType.toLowerCase()) {
       case 'base64':
-        ops.image = ops.image.replace(/^data\:([^\;]+)\;base64,/gmi, '');
-        ops.image = Buffer.alloc(ops.image.length, ops.image, "base64");
+        ops.image = new Buffer(base64ToArrayBuffer(ops.image));
         break;
       case 'arraybuffer':
         ops.image = new Buffer(ops.image);


### PR DESCRIPTION
For some reason when i try to use this in an Angular Application it complains about fs.readFile not existing. So i resorted to using the base64 version of the image binary. I had to modify the library to accept base64 string without interfering with any of the processes that are already existing except converting base64 string to an array buffer and then on to a Buffer ready for processing.
An example usage will be 
`new EXIFImage({ image: this.base64Image, imageDataType: 'base64' }, function (error, exifData) {
        if (error)
          console.log('Error: ' + error.message);
        else {
          console.log(exifData); // Do something with your data!
          var makeAndModel = document.getElementById("makeAndModel");
          makeAndModel.innerHTML = `${exifData.image.Make} ${exifData.image.Model}`;
        }
      });
`
or 
`
new EXIFImage({ image: this.arrayBuffer, imageDataType: 'ArrayBuffer' }, function (error, exifData) {
        if (error)
          console.log('Error: ' + error.message);
        else {
          console.log(exifData); // Do something with your data!
          var makeAndModel = document.getElementById("makeAndModel");
          makeAndModel.innerHTML = `${exifData.image.Make} ${exifData.image.Model}`;
        }
      });
`